### PR TITLE
Update README with info how to add font to CSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,14 @@ And so forth. Currently, the supported font variants are:
 * Bold (`bold`)
 * Black (`black` - font weight 800)
 
+Add it to your CSS styles:
+
+  font-family: 'SourceSansPro';
+
+And adjust the weight in the same way as with any other font:
+
+  font-weight: 400;
+
 ## Building
 
 Font files were downloaded directly from the latest release of [https://github.com/adobe-fonts/source-sans-pro](https://github.com/adobe-fonts/source-sans-pro).


### PR DESCRIPTION
Hi, Thank you for this great gem! It saved me from using Google fonts :) Though at the beginning I spent quite some time looking why it "doesn't work" for me. It seems, that I was adding the name to CSS in a wrong way: "Source Sans Pro" (as Google fonts suggest) instead of "SourceSansPro". I realized that only looking into your code. So I suggest adding these lines to the documentation for people like me :)