### PR TITLE
Bump Minimum Bundler Version

### DIFF
--- a/lib/source-sans-pro/rails/version.rb
+++ b/lib/source-sans-pro/rails/version.rb
@@ -1,5 +1,5 @@
 module SourceSansPro
   module Rails
-    VERSION = '0.7.0'.freeze
+    VERSION = '0.7.1'.freeze
   end
 end

--- a/source-sans-pro-rails.gemspec
+++ b/source-sans-pro-rails.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'railties', '>= 3.2'
 
-  spec.add_development_dependency 'bundler', '~> 1.3'
+  spec.add_development_dependency 'bundler', '>= 2.0.0'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'sass-rails'
   spec.add_development_dependency 'tzinfo'


### PR DESCRIPTION
### Background

Updating the version number for the development dependency of `bundler`. We should be using a minimum version of `2.0.0`.


### Test Plan

Confirm changes work locally for development:

```
bundle install
bundle exec rake install # verify gem installation works
```

In your app, update your gemfile to reference new local version (`0.7.1`) and confirm font still renders correctly in browser locally.